### PR TITLE
feat: allow unsetting transaction category

### DIFF
--- a/e2e/transactions.test.ts
+++ b/e2e/transactions.test.ts
@@ -1,6 +1,7 @@
+import { RecordId } from 'surrealdb';
 import { expect, test } from './utils/surrealdb-test';
 
-test('view transactions', async ({ page, createTransaction, port }) => {
+test('view transactions', async ({ page, pageHelpers, createTransaction }) => {
 	await page.goto('/');
 	const newConnectionButton = page.locator('button', { hasText: 'New Connection' });
 	await newConnectionButton.click();
@@ -12,13 +13,58 @@ test('view transactions', async ({ page, createTransaction, port }) => {
 	});
 
 	// Connect to the database
-	await page.getByRole('textbox', { name: 'URL' }).fill(`ws://127.0.0.1:${port}`);
-	await page.getByRole('textbox', { name: 'Namespace' }).fill('ns');
-	await page.getByRole('textbox', { name: 'Database' }).fill('db');
-	await page.getByRole('button').click();
+	await pageHelpers.connect(page);
 
 	// Check for the transaction
 	await expect(page.getByText('Jan 1 2025')).toBeVisible();
 	await expect(page.getByText(transaction.statementDescription)).toBeVisible();
 	await expect(page.getByText('$1.23')).toBeVisible();
+});
+
+test('clear category', async ({
+	page,
+	pageHelpers,
+	createCategory,
+	createTransaction,
+	surreal
+}) => {
+	await page.goto('/');
+	const newConnectionButton = page.locator('button', { hasText: 'New Connection' });
+	await newConnectionButton.click();
+
+	const category = await createCategory();
+	const transaction = await createTransaction({
+		category: category.id,
+		statementDescription: 'Just a test transaction',
+		date: new Date(2025, 0, 1),
+		amount: -123
+	});
+
+	// Connect to the database
+	await pageHelpers.connect(page);
+
+	// Check for the transaction
+	await expect(page.getByText('Jan 1 2025')).toBeVisible();
+	await expect(page.getByText(transaction.statementDescription)).toBeVisible();
+	await expect(page.getByText('$1.23')).toBeVisible();
+
+	// Remove the category from the transaction
+	await page.getByRole('button', { name: category.emoji }).click();
+	await page.getByRole('button', { name: 'None' }).click();
+
+	const [refreshedTransaction] = await surreal.query<[{ category: RecordId }]>(
+		'select category from transaction where id = $id',
+		{ id: transaction.id }
+	);
+	expect(refreshedTransaction.category).toBeUndefined();
+
+	await page.reload();
+
+	// Connect to the database
+	await page.getByRole('button', { name: 'Last Connection' }).click();
+
+	// The transaction should no longer appear
+	await expect(page.getByRole('heading', { name: 'Transactions' })).toBeVisible();
+	await expect(page.getByText('Jan 1 2025')).not.toBeVisible();
+	await expect(page.getByText('$').first()).toHaveText('$0');
 });

--- a/src/app.css
+++ b/src/app.css
@@ -60,3 +60,8 @@ html {
 	/* @apply bg-yellow-300 dark:bg-yellow-700; */
 	@apply border-l-4 border-yellow-300 dark:border-yellow-700;
 }
+
+.gray-300 {
+	/* @apply bg-gray-300 dark:bg-gray-700; */
+	@apply border-l-4 border-gray-300 dark:border-gray-700;
+}

--- a/src/lib/components/TransactionRow.svelte
+++ b/src/lib/components/TransactionRow.svelte
@@ -14,13 +14,21 @@
 
 	let isSelectingCategory = $state(false);
 
-	async function setCategory(category: Category) {
+	async function setCategory(category: Category | undefined) {
 		await s.setCategory(transaction, category);
 		isSelectingCategory = false;
 	}
+
+	const NONE_CATEGORY: Category = {
+		id: 'none',
+		name: 'None',
+		ordinal: categories.length,
+		color: 'gray-300',
+		emoji: '🚫'
+	};
 </script>
 
-<div class="flex grow-0 flex-row items-center gap-2">
+<div data-transaction class="flex grow-0 flex-row items-center gap-2">
 	<div class="text-xs text-gray-600">
 		<div class="w-12 text-center">
 			{transaction.date.toLocaleDateString(undefined, { month: 'short' })}
@@ -35,7 +43,7 @@
 			</div>
 		{/snippet}
 		{#snippet trigger()}
-			<CategoryPill category={transaction.category} style="short" />
+			<CategoryPill category={transaction.category ?? NONE_CATEGORY} style="short" />
 		{/snippet}
 		{#snippet portal()}
 			<div
@@ -50,6 +58,13 @@
 						<CategoryPill {category} style="full" />
 					</button>
 				{/each}
+				<button
+					tabindex={categories.length}
+					onclick={() => setCategory(undefined)}
+					class="cursor-pointer rounded-md text-left hover:bg-gray-500 hover:text-gray-50"
+				>
+					<CategoryPill category={NONE_CATEGORY} style="full" />
+				</button>
 			</div>
 		{/snippet}
 	</Dropdown>

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -198,7 +198,7 @@ export interface Transaction {
 	id: string;
 	date: Date;
 	amount: number;
-	category: Category;
+	category?: Category;
 	statementId: string;
 	description?: string;
 	statementDescription: string;

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -180,7 +180,7 @@ export class State {
 		this.#surreal = surreal;
 	}
 
-	async setCategory(transaction: Transaction, category: Category) {
+	async setCategory(transaction: Transaction, category: Category | undefined) {
 		if (!this.#surreal) {
 			throw new Error('Not connected to SurrealDB');
 		}
@@ -188,10 +188,16 @@ export class State {
 		const oldCategory = transaction.category;
 		transaction.category = category;
 		try {
-			await this.#surreal.query(`UPDATE $transaction SET category = $category`, {
-				transaction: new RecordId('transaction', transaction.id),
-				category: new RecordId('category', category.id)
-			});
+			if (category) {
+				await this.#surreal.query(`UPDATE $transaction SET category = $category`, {
+					transaction: new RecordId('transaction', transaction.id),
+					category: new RecordId('category', category.id)
+				});
+			} else {
+				await this.#surreal.query(`UPDATE $transaction SET category = none`, {
+					transaction: new RecordId('transaction', transaction.id)
+				});
+			}
 		} catch (error) {
 			console.error(error);
 			this.lastError = error as Error;


### PR DESCRIPTION
Adds a "None" category to the bottom of the category selector to allow specifying that a transaction should not count toward any particular category or show up in totals etc.

<img width="232" alt="Screenshot 2025-04-18 at 9 41 18 PM" src="https://github.com/user-attachments/assets/fefeeeb9-8b5b-4a29-a860-b9ff22178f44" />
