### PR TITLE
fix: clear sticky transactions after changing filters

### DIFF
--- a/e2e/transactions.test.ts
+++ b/e2e/transactions.test.ts
@@ -58,6 +58,9 @@ test('clear category', async ({
 	);
 	expect(refreshedTransaction.category).toBeUndefined();
 
+	// Updates the sums before reloading.
+	await expect(page.getByText('$').first()).toHaveText('$0');
+
 	await page.reload();
 
 	// Connect to the database

--- a/src/lib/components/AccountSelect.svelte
+++ b/src/lib/components/AccountSelect.svelte
@@ -5,9 +5,14 @@
 	import MultiSelector from './MultiSelector.svelte';
 
 	let {
-		selections = $bindable(),
+		selections,
+		selectItems,
 		'aria-label': ariaLabel
-	}: { selections: Selection<Account>[]; 'aria-label'?: string } = $props();
+	}: {
+		selections: Selection<Account>[];
+		selectItems: (keys: readonly string[]) => void;
+		'aria-label'?: string;
+	} = $props();
 
 	let label = $derived(
 		(() => {
@@ -35,6 +40,6 @@
 {/snippet}
 
 <Select aria-label={ariaLabel} {label}>
-	<MultiSelector bind:selections {item} allToggle />
+	<MultiSelector {selections} {selectItems} {item} allToggle />
 	<div class="mt-4 text-xs text-gray-400">Tip: alt+click for just one</div>
 </Select>

--- a/src/lib/components/CategorySelect.svelte
+++ b/src/lib/components/CategorySelect.svelte
@@ -6,9 +6,14 @@
 	import MultiSelector from './MultiSelector.svelte';
 
 	let {
-		selections = $bindable(),
+		selections,
+		selectItems,
 		'aria-label': ariaLabel
-	}: { selections: Selection<Category>[]; 'aria-label'?: string } = $props();
+	}: {
+		selections: Selection<Category>[];
+		selectItems: (keys: readonly string[]) => void;
+		'aria-label'?: string;
+	} = $props();
 
 	let label = $derived(
 		(() => {
@@ -32,7 +37,7 @@
 </script>
 
 <Select aria-label={ariaLabel} {label}>
-	<MultiSelector bind:selections allToggle>
+	<MultiSelector {selections} {selectItems} allToggle>
 		{#snippet item(selection: Selection<Category>)}
 			<span class="text-sm">
 				<CategoryPill category={selection.value} />

--- a/src/lib/components/Filters.svelte
+++ b/src/lib/components/Filters.svelte
@@ -1,15 +1,33 @@
 <script lang="ts">
+	import type { Account, Category } from '$lib/db';
+	import type { Selection } from '$lib/types';
 	import AccountSelect from './AccountSelect.svelte';
 	import CategorySelect from './CategorySelect.svelte';
 	import MonthSelect from './MonthSelect.svelte';
 	import YearSelect from './YearSelect.svelte';
 
 	let {
-		yearSelections = $bindable(),
-		monthSelections = $bindable(),
-		categorySelections = $bindable(),
-		accountSelections = $bindable(),
-		searchTerm = $bindable()
+		yearSelections,
+		monthSelections,
+		categorySelections,
+		accountSelections,
+		searchTerm,
+		selectYears,
+		selectMonths,
+		selectCategories,
+		selectAccounts,
+		updateSearchTerm
+	}: {
+		yearSelections: Selection<number>[];
+		monthSelections: Selection<number>[];
+		categorySelections: Selection<Category>[];
+		accountSelections: Selection<Account>[];
+		searchTerm: string;
+		selectYears: (keys: readonly string[]) => void;
+		selectMonths: (keys: readonly string[]) => void;
+		selectCategories: (keys: readonly string[]) => void;
+		selectAccounts: (keys: readonly string[]) => void;
+		updateSearchTerm: (searchTerm: string) => void;
 	} = $props();
 
 	let editableSearchTerm = $state(searchTerm);
@@ -17,7 +35,7 @@
 	$effect(() => {
 		let newSearchTerm = editableSearchTerm;
 		let timeout = setTimeout(() => {
-			searchTerm = newSearchTerm;
+			updateSearchTerm(newSearchTerm);
 		}, 300);
 		return () => clearTimeout(timeout);
 	});
@@ -25,10 +43,18 @@
 
 <div class="flex flex-row items-center gap-1">
 	<span class="font-bold">Filters:</span>
-	<YearSelect aria-label="Year Filter" bind:selections={yearSelections} />
-	<MonthSelect aria-label="Month Filter" bind:selections={monthSelections} />
-	<CategorySelect aria-label="Category Filter" bind:selections={categorySelections} />
-	<AccountSelect aria-label="Account Filter" bind:selections={accountSelections} />
+	<YearSelect aria-label="Year Filter" selections={yearSelections} selectItems={selectYears} />
+	<MonthSelect aria-label="Month Filter" selections={monthSelections} selectItems={selectMonths} />
+	<CategorySelect
+		aria-label="Category Filter"
+		selections={categorySelections}
+		selectItems={selectCategories}
+	/>
+	<AccountSelect
+		aria-label="Account Filter"
+		selections={accountSelections}
+		selectItems={selectAccounts}
+	/>
 	<input
 		type="text"
 		placeholder="Search"

--- a/src/lib/components/MonthSelect.svelte
+++ b/src/lib/components/MonthSelect.svelte
@@ -5,9 +5,14 @@
 	import MultiSelector from './MultiSelector.svelte';
 
 	let {
-		selections = $bindable(),
+		selections,
+		selectItems,
 		'aria-label': ariaLabel
-	}: { selections: Selection<number>[]; 'aria-label'?: string } = $props();
+	}: {
+		selections: Selection<number>[];
+		selectItems: (keys: readonly string[]) => void;
+		'aria-label'?: string;
+	} = $props();
 
 	let label = $derived(
 		(() => {
@@ -47,6 +52,6 @@
 {/snippet}
 
 <Select aria-label={ariaLabel} {label}>
-	<MultiSelector bind:selections {item} allToggle />
+	<MultiSelector {selections} {item} allToggle {selectItems} />
 	<div class="mt-4 text-xs text-gray-400">Tip: alt+click for just one</div>
 </Select>

--- a/src/lib/components/MultiSelector.svelte
+++ b/src/lib/components/MultiSelector.svelte
@@ -2,13 +2,15 @@
 	import type { Snippet } from 'svelte';
 
 	let {
-		selections = $bindable(),
+		selections,
 		item,
-		allToggle
+		allToggle,
+		selectItems
 	}: {
 		selections: Item[];
 		item: Snippet<[Item]>;
 		allToggle?: boolean;
+		selectItems: (keys: readonly string[]) => void;
 	} = $props();
 </script>
 
@@ -20,9 +22,8 @@
 					type="checkbox"
 					checked={selections.every((selection) => selection.selected)}
 					onclick={(e) => {
-						for (const selection of selections) {
-							selection.selected = e.currentTarget.checked;
-						}
+						const checked = e.currentTarget.checked;
+						selectItems(checked ? selections.map(({ key }) => key) : []);
 					}}
 				/>
 				All
@@ -33,16 +34,25 @@
 			<label class="cursor-pointer">
 				<input
 					type="checkbox"
-					bind:checked={selection.selected}
+					bind:checked={
+						() => selection.selected,
+						(checked) =>
+							selectItems(
+								selections
+									.filter((s) => (s.key === selection.key ? checked : s.selected))
+									.map(({ key }) => key)
+							)
+					}
 					onclick={(e) => {
 						if (e.altKey) {
 							const selected = selections.filter((s) => s.selected);
 							const thisSelected = selected.length !== 1 || selected[0] !== selection;
 
-							for (const selection of selections) {
-								selection.selected = !thisSelected;
-							}
-							selection.selected = thisSelected;
+							selectItems(
+								thisSelected
+									? [selection.key]
+									: selections.filter((s) => s !== selection).map(({ key }) => key)
+							);
 						}
 					}}
 				/>

--- a/src/lib/components/YearSelect.svelte
+++ b/src/lib/components/YearSelect.svelte
@@ -5,9 +5,14 @@
 	import MultiSelector from './MultiSelector.svelte';
 
 	let {
-		selections = $bindable(),
+		selections,
+		selectItems,
 		'aria-label': ariaLabel
-	}: { selections: Selection<number>[]; 'aria-label'?: string } = $props();
+	}: {
+		selections: Selection<number>[];
+		selectItems: (keys: readonly string[]) => void;
+		'aria-label'?: string;
+	} = $props();
 
 	let label = $derived(
 		(() => {
@@ -38,6 +43,6 @@
 {/snippet}
 
 <Select {label} aria-label={ariaLabel}>
-	<MultiSelector bind:selections {item} allToggle />
+	<MultiSelector {selections} {item} allToggle {selectItems} />
 	<div class="mt-4 text-xs text-gray-400">Tip: alt+click for just one</div>
 </Select>

--- a/src/lib/screens/TransactionsScreen.svelte
+++ b/src/lib/screens/TransactionsScreen.svelte
@@ -31,11 +31,16 @@
 	</div>
 	{#if s.filters}
 		<Filters
-			bind:yearSelections={s.filters.years}
-			bind:monthSelections={s.filters.months}
-			bind:categorySelections={s.filters.categories}
-			bind:accountSelections={s.filters.accounts}
-			bind:searchTerm={s.filters.searchTerm}
+			yearSelections={s.filters.years}
+			monthSelections={s.filters.months}
+			categorySelections={s.filters.categories}
+			accountSelections={s.filters.accounts}
+			searchTerm={s.filters.searchTerm}
+			selectYears={s.selectYears.bind(s)}
+			selectMonths={s.selectMonths.bind(s)}
+			selectCategories={s.selectCategories.bind(s)}
+			selectAccounts={s.selectAccounts.bind(s)}
+			updateSearchTerm={s.updateSearchTerm.bind(s)}
 		/>
 	{/if}
 

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -170,6 +170,50 @@ export class State {
 		);
 	}
 
+	selectYears(keys: readonly string[]): void {
+		this.#updateFiltersWith((filters) => {
+			for (const yearFilter of filters.years) {
+				yearFilter.selected = keys.includes(yearFilter.key);
+			}
+		});
+	}
+
+	selectMonths(keys: readonly string[]): void {
+		this.#updateFiltersWith((filters) => {
+			for (const monthFilter of filters.months) {
+				monthFilter.selected = keys.includes(monthFilter.key);
+			}
+		});
+	}
+
+	selectCategories(keys: readonly string[]): void {
+		this.#updateFiltersWith((filters) => {
+			for (const categoryFilter of filters.categories) {
+				categoryFilter.selected = keys.includes(categoryFilter.key);
+			}
+		});
+	}
+
+	selectAccounts(keys: readonly string[]): void {
+		this.#updateFiltersWith((filters) => {
+			for (const accountFilter of filters.accounts) {
+				accountFilter.selected = keys.includes(accountFilter.key);
+			}
+		});
+	}
+
+	updateSearchTerm(searchTerm: string): void {
+		this.#updateFiltersWith((filters) => {
+			filters.searchTerm = searchTerm;
+		});
+	}
+
+	#updateFiltersWith(callback: (filters: FilterState) => void): void {
+		if (!this.filters) return;
+		this.filters.stickyTransactionIds.clear();
+		callback(this.filters);
+	}
+
 	get isConnected() {
 		return !!this.#surreal;
 	}


### PR DESCRIPTION
When updating the current set of filters the current set of transactions preserved in the list would not change, but they should be removed when the filters change.