### PR TITLE
fix: make filter checkboxes work properly again

### DIFF
--- a/e2e/transactions.test.ts
+++ b/e2e/transactions.test.ts
@@ -1,5 +1,6 @@
 import { RecordId } from 'surrealdb';
 import { expect, test } from './utils/surrealdb-test';
+import { waitFor } from './utils/helpers';
 
 test('view transactions', async ({ page, pageHelpers, createTransaction }) => {
 	await page.goto('/');
@@ -48,18 +49,23 @@ test('clear category', async ({
 	await expect(page.getByText(transaction.statementDescription)).toBeVisible();
 	await expect(page.getByText('$1.23')).toBeVisible();
 
+	const categorySummaryValue = page.getByTestId(`${category.id}-summary-value`);
+	await expect(categorySummaryValue).toHaveText('$1');
+
 	// Remove the category from the transaction
 	await page.getByRole('button', { name: category.emoji }).click();
 	await page.getByRole('button', { name: 'None' }).click();
 
-	const [refreshedTransaction] = await surreal.query<[{ category: RecordId }]>(
-		'select category from transaction where id = $id',
-		{ id: transaction.id }
-	);
-	expect(refreshedTransaction.category).toBeUndefined();
+	await waitFor(async () => {
+		const [refreshedTransaction] = await surreal.query<[{ category?: RecordId }]>(
+			'select category from transaction where id = $id',
+			{ id: transaction.id }
+		);
+		expect(refreshedTransaction.category).toBeUndefined();
+	});
 
 	// Updates the sums before reloading.
-	await expect(page.getByText('$').first()).toHaveText('$0');
+	await expect(categorySummaryValue).toHaveText('$0');
 
 	await page.reload();
 
@@ -73,4 +79,120 @@ test('clear category', async ({
 	for (const locator of await page.getByText('$').all()) {
 		await expect(locator).toHaveText('$0');
 	}
+});
+
+test('update category', async ({
+	page,
+	pageHelpers,
+	createCategory,
+	createTransaction,
+	surreal
+}) => {
+	await page.goto('/');
+	const newConnectionButton = page.locator('button', { hasText: 'New Connection' });
+	await newConnectionButton.click();
+
+	const category1 = await createCategory({
+		name: 'General',
+		emoji: '🛍️'
+	});
+	const category2 = await createCategory({
+		name: 'Utilities',
+		emoji: '⚡'
+	});
+	const transaction = await createTransaction({
+		category: category1.id,
+		statementDescription: 'Just a test transaction',
+		date: new Date(2025, 0, 1),
+		amount: -123
+	});
+
+	// Connect to the database
+	await pageHelpers.connect(page);
+
+	const category1SummaryValue = page.getByTestId(`${category1.id}-summary-value`);
+	const category2SummaryValue = page.getByTestId(`${category2.id}-summary-value`);
+
+	// Initially, transaction is assigned to category1.
+	await expect(category1SummaryValue).toHaveText('$1');
+	await expect(category2SummaryValue).toHaveText('$0');
+
+	// Change the category
+	await page.getByRole('button', { name: category1.emoji }).click();
+	await page.getByRole('button', { name: category2.name }).click();
+
+	await waitFor(async () => {
+		const [refreshedTransaction] = await surreal.query<[{ category?: RecordId }]>(
+			'select category from only transaction where id = $id limit 1',
+			{ id: transaction.id }
+		);
+		expect(refreshedTransaction.category).toEqual(category2.id);
+	});
+
+	// Now, transaction is assigned to category2.
+	await expect(category1SummaryValue).toHaveText('$0');
+	await expect(category2SummaryValue).toHaveText('$1');
+});
+
+test('updating to hidden category', async ({
+	page,
+	pageHelpers,
+	createCategory,
+	createTransaction,
+	surreal
+}) => {
+	await page.goto('/');
+	const newConnectionButton = page.locator('button', { hasText: 'New Connection' });
+	await newConnectionButton.click();
+
+	const generalCategory = await createCategory({
+		name: 'General',
+		emoji: '🛍️'
+	});
+	const utilitiesCategory = await createCategory({
+		name: 'Utilities',
+		emoji: '⚡'
+	});
+	const generalTransaction = await createTransaction({
+		category: generalCategory.id,
+		statementDescription: 'Just a test transaction',
+		date: new Date(2025, 0, 1),
+		amount: -100
+	});
+	await createTransaction({
+		category: utilitiesCategory.id,
+		statementDescription: '"Utilities" transaction',
+		date: new Date(2024, 0, 1),
+		amount: -100
+	});
+
+	// Connect to the database
+	await pageHelpers.connect(page);
+
+	// Hide "Utilities".
+	await page.getByLabel('Category Filter').click();
+	await expect(page.getByRole('checkbox', { name: '🛍️ General' })).toBeVisible();
+	await expect(page.getByRole('checkbox', { name: '⚡ Utilities' })).toBeVisible();
+	await page.getByRole('checkbox', { name: '⚡ Utilities' }).click();
+
+	// Change the category
+	await page.getByRole('button', { name: generalCategory.emoji }).click();
+	await page.getByRole('button', { name: '⚡ Utilities' }).click();
+
+	await waitFor(async () => {
+		const [refreshedTransaction] = await surreal.query<[{ category?: RecordId }]>(
+			'select category from only transaction where id = $id limit 1',
+			{ id: generalTransaction.id }
+		);
+		expect(refreshedTransaction.category).toEqual(utilitiesCategory.id);
+	});
+
+	// Check that the transaction is still shown.
+	await expect(page.getByText(generalTransaction.statementDescription)).toBeVisible();
+
+	// Update the filters.
+	await page.getByRole('textbox', { name: 'Search' }).fill('test');
+
+	// Check that the transaction is now hidden.
+	await expect(page.getByText(generalTransaction.statementDescription)).not.toBeVisible();
 });

--- a/e2e/utils/helpers.ts
+++ b/e2e/utils/helpers.ts
@@ -1,0 +1,25 @@
+export async function waitFor(
+	fn: () => unknown,
+	{ timeout = 4000 }: { timeout?: number } = {}
+): Promise<void> {
+	const end = Date.now() + timeout;
+	let lastError: Error | undefined;
+
+	while (end > Date.now()) {
+		try {
+			const result = await fn();
+
+			if (result !== true) {
+				return;
+			}
+		} catch (e) {
+			lastError = e as Error;
+		}
+	}
+
+	if (lastError) {
+		throw new Error(`Timed out waiting for predicate. ${lastError}`);
+	}
+
+	throw new Error('Timed out waiting for predicate');
+}

--- a/src/lib/components/AccountSelect.svelte
+++ b/src/lib/components/AccountSelect.svelte
@@ -5,12 +5,10 @@
 	import MultiSelector from './MultiSelector.svelte';
 
 	let {
-		selections,
-		selectItems,
+		selections = $bindable(),
 		'aria-label': ariaLabel
 	}: {
 		selections: Selection<Account>[];
-		selectItems: (keys: readonly string[]) => void;
 		'aria-label'?: string;
 	} = $props();
 
@@ -40,6 +38,6 @@
 {/snippet}
 
 <Select aria-label={ariaLabel} {label}>
-	<MultiSelector {selections} {selectItems} {item} allToggle />
+	<MultiSelector bind:selections {item} allToggle />
 	<div class="mt-4 text-xs text-gray-400">Tip: alt+click for just one</div>
 </Select>

--- a/src/lib/components/CategorySelect.svelte
+++ b/src/lib/components/CategorySelect.svelte
@@ -6,12 +6,10 @@
 	import MultiSelector from './MultiSelector.svelte';
 
 	let {
-		selections,
-		selectItems,
+		selections = $bindable(),
 		'aria-label': ariaLabel
 	}: {
 		selections: Selection<Category>[];
-		selectItems: (keys: readonly string[]) => void;
 		'aria-label'?: string;
 	} = $props();
 
@@ -37,7 +35,7 @@
 </script>
 
 <Select aria-label={ariaLabel} {label}>
-	<MultiSelector {selections} {selectItems} allToggle>
+	<MultiSelector bind:selections allToggle>
 		{#snippet item(selection: Selection<Category>)}
 			<span class="text-sm">
 				<CategoryPill category={selection.value} />

--- a/src/lib/components/Filters.svelte
+++ b/src/lib/components/Filters.svelte
@@ -7,27 +7,17 @@
 	import YearSelect from './YearSelect.svelte';
 
 	let {
-		yearSelections,
-		monthSelections,
-		categorySelections,
-		accountSelections,
-		searchTerm,
-		selectYears,
-		selectMonths,
-		selectCategories,
-		selectAccounts,
-		updateSearchTerm
+		yearSelections = $bindable(),
+		monthSelections = $bindable(),
+		categorySelections = $bindable(),
+		accountSelections = $bindable(),
+		searchTerm = $bindable()
 	}: {
 		yearSelections: Selection<number>[];
 		monthSelections: Selection<number>[];
 		categorySelections: Selection<Category>[];
 		accountSelections: Selection<Account>[];
 		searchTerm: string;
-		selectYears: (keys: readonly string[]) => void;
-		selectMonths: (keys: readonly string[]) => void;
-		selectCategories: (keys: readonly string[]) => void;
-		selectAccounts: (keys: readonly string[]) => void;
-		updateSearchTerm: (searchTerm: string) => void;
 	} = $props();
 
 	let editableSearchTerm = $state(searchTerm);
@@ -35,7 +25,7 @@
 	$effect(() => {
 		let newSearchTerm = editableSearchTerm;
 		let timeout = setTimeout(() => {
-			updateSearchTerm(newSearchTerm);
+			searchTerm = newSearchTerm;
 		}, 300);
 		return () => clearTimeout(timeout);
 	});
@@ -43,18 +33,10 @@
 
 <div class="flex flex-row items-center gap-1">
 	<span class="font-bold">Filters:</span>
-	<YearSelect aria-label="Year Filter" selections={yearSelections} selectItems={selectYears} />
-	<MonthSelect aria-label="Month Filter" selections={monthSelections} selectItems={selectMonths} />
-	<CategorySelect
-		aria-label="Category Filter"
-		selections={categorySelections}
-		selectItems={selectCategories}
-	/>
-	<AccountSelect
-		aria-label="Account Filter"
-		selections={accountSelections}
-		selectItems={selectAccounts}
-	/>
+	<YearSelect aria-label="Year Filter" bind:selections={yearSelections} />
+	<MonthSelect aria-label="Month Filter" bind:selections={monthSelections} />
+	<CategorySelect aria-label="Category Filter" bind:selections={categorySelections} />
+	<AccountSelect aria-label="Account Filter" bind:selections={accountSelections} />
 	<input
 		type="text"
 		placeholder="Search"

--- a/src/lib/components/MonthSelect.svelte
+++ b/src/lib/components/MonthSelect.svelte
@@ -5,12 +5,10 @@
 	import MultiSelector from './MultiSelector.svelte';
 
 	let {
-		selections,
-		selectItems,
+		selections = $bindable(),
 		'aria-label': ariaLabel
 	}: {
 		selections: Selection<number>[];
-		selectItems: (keys: readonly string[]) => void;
 		'aria-label'?: string;
 	} = $props();
 
@@ -52,6 +50,6 @@
 {/snippet}
 
 <Select aria-label={ariaLabel} {label}>
-	<MultiSelector {selections} {item} allToggle {selectItems} />
+	<MultiSelector bind:selections {item} allToggle />
 	<div class="mt-4 text-xs text-gray-400">Tip: alt+click for just one</div>
 </Select>

--- a/src/lib/components/MultiSelector.svelte
+++ b/src/lib/components/MultiSelector.svelte
@@ -2,15 +2,13 @@
 	import type { Snippet } from 'svelte';
 
 	let {
-		selections,
+		selections = $bindable(),
 		item,
-		allToggle,
-		selectItems
+		allToggle
 	}: {
 		selections: Item[];
 		item: Snippet<[Item]>;
 		allToggle?: boolean;
-		selectItems: (keys: readonly string[]) => void;
 	} = $props();
 </script>
 
@@ -22,8 +20,9 @@
 					type="checkbox"
 					checked={selections.every((selection) => selection.selected)}
 					onclick={(e) => {
-						const checked = e.currentTarget.checked;
-						selectItems(checked ? selections.map(({ key }) => key) : []);
+						for (const selection of selections) {
+							selection.selected = e.currentTarget.checked;
+						}
 					}}
 				/>
 				All
@@ -34,25 +33,16 @@
 			<label class="cursor-pointer">
 				<input
 					type="checkbox"
-					bind:checked={
-						() => selection.selected,
-						(checked) =>
-							selectItems(
-								selections
-									.filter((s) => (s.key === selection.key ? checked : s.selected))
-									.map(({ key }) => key)
-							)
-					}
+					bind:checked={selection.selected}
 					onclick={(e) => {
 						if (e.altKey) {
 							const selected = selections.filter((s) => s.selected);
 							const thisSelected = selected.length !== 1 || selected[0] !== selection;
 
-							selectItems(
-								thisSelected
-									? [selection.key]
-									: selections.filter((s) => s !== selection).map(({ key }) => key)
-							);
+							for (const selection of selections) {
+								selection.selected = !thisSelected;
+							}
+							selection.selected = thisSelected;
 						}
 					}}
 				/>

--- a/src/lib/components/TransactionRow.svelte
+++ b/src/lib/components/TransactionRow.svelte
@@ -43,7 +43,10 @@
 			</div>
 		{/snippet}
 		{#snippet trigger()}
-			<CategoryPill category={transaction.category ?? NONE_CATEGORY} style="short" />
+			<CategoryPill
+				category={categories.find((c) => c.id === transaction.categoryId) ?? NONE_CATEGORY}
+				style="short"
+			/>
 		{/snippet}
 		{#snippet portal()}
 			<div

--- a/src/lib/components/YearSelect.svelte
+++ b/src/lib/components/YearSelect.svelte
@@ -5,12 +5,10 @@
 	import MultiSelector from './MultiSelector.svelte';
 
 	let {
-		selections,
-		selectItems,
+		selections = $bindable(),
 		'aria-label': ariaLabel
 	}: {
 		selections: Selection<number>[];
-		selectItems: (keys: readonly string[]) => void;
 		'aria-label'?: string;
 	} = $props();
 
@@ -43,6 +41,6 @@
 {/snippet}
 
 <Select {label} aria-label={ariaLabel}>
-	<MultiSelector {selections} {item} allToggle {selectItems} />
+	<MultiSelector bind:selections {item} allToggle />
 	<div class="mt-4 text-xs text-gray-400">Tip: alt+click for just one</div>
 </Select>

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -121,9 +121,12 @@ export async function getTransactions(
 ): Promise<Transactions> {
 	const b = getTransactionsQueryBindings;
 	console.time('getTransactions: fetch from surrealdb');
-	abortSignal.addEventListener('abort', () => {
+
+	function onAbort() {
 		console.timeEnd('getTransactions: fetch from surrealdb');
-	});
+		abortSignal.removeEventListener('abort', onAbort);
+	}
+	abortSignal.addEventListener('abort', onAbort);
 
 	const data = await surreal.query(
 		options.sort.direction === 'asc'
@@ -140,6 +143,7 @@ export async function getTransactions(
 			b.orderByField.fill(options.sort.field)
 		]
 	);
+	abortSignal.removeEventListener('abort', onAbort);
 	if (abortSignal.aborted) return NEVER_PROMISE;
 
 	console.timeEnd('getTransactions: fetch from surrealdb');

--- a/src/lib/screens/ConnectionScreen.svelte
+++ b/src/lib/screens/ConnectionScreen.svelte
@@ -4,7 +4,7 @@
 	import BigButton from '../components/BigButton.svelte';
 	import CircleStack from '../components/icons/CircleStack.svelte';
 
-	let { state: s }: { state: State } = $props();
+	let { state: s = $bindable() }: { state: State } = $props();
 	let isSettingUpNewConnection = $state(false);
 	let url = $state('');
 	let namespace = $state('');

--- a/src/lib/screens/TransactionsScreen.svelte
+++ b/src/lib/screens/TransactionsScreen.svelte
@@ -5,12 +5,13 @@
 	import TransactionRow from '$lib/components/TransactionRow.svelte';
 	import type { State } from '$lib/state.svelte';
 	import { formatWholeDollarAmount } from '$lib/utils/formatting';
+	import { RecordId } from 'surrealdb';
 	import { type Snippet } from 'svelte';
 	import { VList } from 'virtua/svelte';
 	import IconTallyMark5 from '~icons/mdi/tally-mark-5';
 	import IconDollarCoinSolid from '~icons/streamline/dollar-coin-solid';
 
-	let { state: s }: { state: State } = $props();
+	let { state: s = $bindable() }: { state: State } = $props();
 </script>
 
 <title>Transactions – Summer</title>
@@ -31,16 +32,11 @@
 	</div>
 	{#if s.filters}
 		<Filters
-			yearSelections={s.filters.years}
-			monthSelections={s.filters.months}
-			categorySelections={s.filters.categories}
-			accountSelections={s.filters.accounts}
-			searchTerm={s.filters.searchTerm}
-			selectYears={s.selectYears.bind(s)}
-			selectMonths={s.selectMonths.bind(s)}
-			selectCategories={s.selectCategories.bind(s)}
-			selectAccounts={s.selectAccounts.bind(s)}
-			updateSearchTerm={s.updateSearchTerm.bind(s)}
+			bind:yearSelections={s.filters.years}
+			bind:monthSelections={s.filters.months}
+			bind:categorySelections={s.filters.categories}
+			bind:accountSelections={s.filters.accounts}
+			bind:searchTerm={s.filters.searchTerm}
 		/>
 	{/if}
 
@@ -66,10 +62,10 @@
 		</div>
 
 		<div class="h-dvh w-3/12 grow-2">
-			{#snippet summaryRow(label: Snippet, value: string)}
+			{#snippet summaryRow(label: Snippet, value: string, valueTestId?: string)}
 				<div class="flex flex-row items-baseline gap-0">
 					<span class="overflow-hidden overflow-ellipsis whitespace-nowrap">{@render label()}</span>
-					<span class="grow-1 text-right">{value}</span>
+					<span class="grow-1 text-right" data-testid={valueTestId}>{value}</span>
 				</div>
 			{/snippet}
 			<h3 class="font-bold">Total by Year</h3>
@@ -114,7 +110,12 @@
 							class="overflow-hidden overflow-ellipsis whitespace-nowrap"
 						/>
 					{/snippet}
-					{@render summaryRow(label, formatWholeDollarAmount(total))}
+
+					{@render summaryRow(
+						label,
+						formatWholeDollarAmount(total),
+						`${new RecordId('category', category.id)}-summary-value`
+					)}
 				{/each}
 			{/if}
 

--- a/src/lib/utils/Fetcher.test.ts
+++ b/src/lib/utils/Fetcher.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from 'bun:test';
+import { Fetcher } from './Fetcher';
+
+test('basic', async () => {
+	const fetcher = new Fetcher(
+		() =>
+			new Promise<number>((resolve) => {
+				setTimeout(() => resolve(99), 1);
+			})
+	);
+
+	expect(await fetcher.fetch()).toEqual(99);
+});
+
+test('keeps only the most recent', async () => {
+	let ret = 0;
+
+	const fetcher = new Fetcher(
+		() =>
+			new Promise<number>((resolve) => {
+				setTimeout(() => {
+					ret += 1;
+					resolve(ret);
+				}, 1);
+			})
+	);
+
+	const promise1 = fetcher.fetch();
+	const promise2 = fetcher.fetch();
+
+	// neither has run yet
+	expect(ret).toEqual(0);
+
+	// wait for the first one to resolve, which should be the second
+	expect(await Promise.race([promise1, promise2])).toEqual(2);
+
+	// both have run their course
+	expect(ret).toEqual(2);
+});
+
+test('abort signal', async () => {
+	let aborted = 0;
+
+	const fetcher = new Fetcher<[], void>(async (abortSignal) => {
+		abortSignal.addEventListener('abort', () => {
+			aborted += 1;
+		});
+	});
+
+	const promise1 = fetcher.fetch();
+	expect(aborted).toEqual(0);
+	await promise1;
+	expect(aborted).toEqual(0);
+
+	const promise2 = fetcher.fetch();
+	const promise3 = fetcher.fetch();
+	expect(aborted).toEqual(1);
+	await Promise.race([promise2, promise3]);
+});

--- a/src/lib/utils/Fetcher.ts
+++ b/src/lib/utils/Fetcher.ts
@@ -1,0 +1,40 @@
+import { NEVER_PROMISE } from './promises';
+
+/**
+ * Fetch using the provided async function, but only return the most recent
+ * result. The provided fetch function is given an `AbortSignal` to detect when
+ * it should consider its request to be outdated.
+ */
+export class Fetcher<Args extends unknown[], Return> {
+	#fetch: (...args: [...Args, AbortSignal]) => Promise<Return>;
+	#lastAbortController: AbortController | undefined;
+
+	constructor(fetch: (...args: [...Args, abortSignal: AbortSignal]) => Promise<Return>) {
+		this.#fetch = fetch;
+	}
+
+	/**
+	 * Fetch data using the provided fetcher. This will only resolve if it was
+	 * the latest fetch when the inner fetch function resolved.
+	 */
+	async fetch(...args: Args): Promise<Return> {
+		// signal that the last fetch should be aborted
+		this.#lastAbortController?.abort();
+
+		// schedule this fetch
+		const abortController = new AbortController();
+		this.#lastAbortController = abortController;
+		const ret = await this.#fetch(...args, abortController.signal);
+
+		if (this.#lastAbortController === abortController) {
+			this.#lastAbortController = undefined;
+		}
+
+		if (abortController.signal.aborted) {
+			// never return from an `await` on this fetch
+			return NEVER_PROMISE;
+		}
+
+		return ret;
+	}
+}

--- a/src/lib/utils/Filters.svelte.ts
+++ b/src/lib/utils/Filters.svelte.ts
@@ -1,0 +1,60 @@
+import type { Account, Category, FilterOptions } from '$lib/db';
+import type { Selection } from '$lib/types';
+
+export class Filters {
+	years: Selection<number>[] = $state([]);
+	months: Selection<number>[] = $state([]);
+	categories: Selection<Category>[] = $state([]);
+	accounts: Selection<Account>[] = $state([]);
+	searchTerm = $state('');
+	#stickyTransactionIds: string[] = $state([]);
+
+	constructor() {
+		this.#enableResetStickyTransactionsEffect();
+	}
+
+	#enableResetStickyTransactionsEffect() {
+		$effect(() => {
+			// If any of these change…
+			for (const selection of [...this.accounts, ...this.categories, ...this.months, ...this.years])
+				void selection.selected;
+			void this.searchTerm;
+
+			// …clear the list of sticky transactions.
+			console.log('clearing sticky transaction IDs');
+			this.#stickyTransactionIds.length = 0;
+		});
+	}
+
+	addStickyTransactionId(id: string): void {
+		this.#stickyTransactionIds.push(id);
+	}
+
+	get stickyTransactionIds(): Set<string> {
+		return new Set(this.#stickyTransactionIds);
+	}
+
+	resetOptions(filterOptions: FilterOptions): void {
+		this.years = filterOptions.years.map((year) => ({
+			key: year.toString(),
+			value: year,
+			selected: true
+		}));
+		this.months = filterOptions.months.map((month) => ({
+			key: month.toString(),
+			value: month,
+			selected: true
+		}));
+		this.accounts = filterOptions.accounts.map((account) => ({
+			key: account.id.toString(),
+			value: account,
+			selected: true
+		}));
+		this.categories = filterOptions.categories.map((category) => ({
+			key: category.id.toString(),
+			value: category,
+			selected: true
+		}));
+		this.searchTerm = '';
+	}
+}

--- a/src/lib/utils/promises.ts
+++ b/src/lib/utils/promises.ts
@@ -1,0 +1,1 @@
+export const NEVER_PROMISE = new Promise<never>(() => {});

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,7 +7,7 @@
 </script>
 
 {#if !s.isConnected}
-	<ConnectionScreen state={s} />
+	<ConnectionScreen bind:state={s} />
 {:else}
-	<TransactionsScreen state={s} />
+	<TransactionsScreen bind:state={s} />
 {/if}


### PR DESCRIPTION
I broke the alt-click toggling in #19. This fixes it by bringing back the bindings and embracing the seeming fact that I cannot escape from using `$effect` for synchronizing state.