### PR TITLE
refactor: use context API for shared state

### DIFF
--- a/src/lib/components/TransactionRow.svelte
+++ b/src/lib/components/TransactionRow.svelte
@@ -2,15 +2,13 @@
 	import type { Category, Transaction } from '$lib/db';
 	import type { State } from '$lib/state.svelte';
 	import { formatTransactionAmount } from '$lib/utils/formatting';
+	import { getContext } from 'svelte';
 	import CategoryPill from './CategoryPill.svelte';
 	import Dropdown from './Dropdown.svelte';
 	import TransactionDescription from './TransactionDescription.svelte';
 
-	let {
-		state: s,
-		transaction,
-		categories
-	}: { state: State; transaction: Transaction; categories: Category[] } = $props();
+	let s: State = getContext('state');
+	let { transaction, categories }: { transaction: Transaction; categories: Category[] } = $props();
 
 	let isSelectingCategory = $state(false);
 

--- a/src/lib/screens/AccountsScreen.svelte
+++ b/src/lib/screens/AccountsScreen.svelte
@@ -3,8 +3,9 @@
 	import NavigationButton from '$lib/components/NavigationButton.svelte';
 	import type { Account } from '$lib/db';
 	import type { State } from '$lib/state.svelte';
+	import { getContext } from 'svelte';
 
-	let { state: s = $bindable() }: { state: State } = $props();
+	const s: State = getContext('state');
 
 	const NEW_ACCOUNT: Partial<Account> = {
 		id: 'new-account',

--- a/src/lib/screens/ConnectionScreen.svelte
+++ b/src/lib/screens/ConnectionScreen.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
 	import ErrorAlert from '$lib/components/ErrorAlert.svelte';
 	import type { State } from '$lib/state.svelte';
+	import { getContext } from 'svelte';
 	import BigButton from '../components/BigButton.svelte';
 	import CircleStack from '../components/icons/CircleStack.svelte';
 
-	let { state: s = $bindable() }: { state: State } = $props();
+	let s: State = getContext('state');
+
 	let isSettingUpNewConnection = $state(false);
 	let url = $state('');
 	let namespace = $state('');

--- a/src/lib/screens/TransactionsScreen.svelte
+++ b/src/lib/screens/TransactionsScreen.svelte
@@ -7,12 +7,12 @@
 	import type { State } from '$lib/state.svelte';
 	import { formatWholeDollarAmount } from '$lib/utils/formatting';
 	import { RecordId } from 'surrealdb';
-	import { type Snippet } from 'svelte';
+	import { getContext, type Snippet } from 'svelte';
 	import { VList } from 'virtua/svelte';
 	import IconTallyMark5 from '~icons/mdi/tally-mark-5';
 	import IconDollarCoinSolid from '~icons/streamline/dollar-coin-solid';
 
-	let { state: s = $bindable() }: { state: State } = $props();
+	let s: State = getContext('state');
 </script>
 
 <title>Transactions – Summer</title>
@@ -48,12 +48,10 @@
 				<div class="text-2xl font-bold">Loading…</div>
 			</div>
 		{:else}
-			{@const transactions = s.transactions.list}
 			<SortHeader sort={s.sort} />
-			<VList data={transactions} getKey={(transaction) => transaction.id}>
+			<VList data={s.transactions.list} getKey={(transaction) => transaction.id}>
 				{#snippet children(transaction)}
 					<TransactionRow
-						state={s}
 						{transaction}
 						categories={s.filters?.categories.map(({ value }) => value) ?? []}
 					/>

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -9,9 +9,9 @@ import {
 	type Transaction,
 	type Transactions
 } from './db';
-import { Filters } from './utils/Filters.svelte';
 import type { Selection } from './types';
 import { Fetcher } from './utils/Fetcher';
+import { Filters } from './utils/Filters.svelte';
 import { NEVER_PROMISE } from './utils/promises';
 
 const LOCAL_STORAGE_KEY = 'lastDb';
@@ -86,13 +86,6 @@ export class State {
 			'date'
 		)
 	);
-
-	static #shared?: State;
-
-	static get shared(): State {
-		this.#shared ??= new State();
-		return this.#shared;
-	}
 
 	constructor() {
 		const lastDb = localStorage.getItem(LOCAL_STORAGE_KEY);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,15 +1,17 @@
 <script lang="ts">
-	import type { Snippet } from 'svelte';
-	import '../app.css';
-	import { State } from '$lib/state.svelte';
 	import ConnectionScreen from '$lib/screens/ConnectionScreen.svelte';
+	import { State } from '$lib/state.svelte';
+	import { setContext, type Snippet } from 'svelte';
+	import '../app.css';
 
-	let s = State.shared;
+	let s = new State();
+	setContext('state', s);
+
 	let { children }: { children: Snippet } = $props();
 </script>
 
 {#if !s.isConnected}
-	<ConnectionScreen state={s} />
+	<ConnectionScreen />
 {:else}
 	<div class="flex h-screen w-screen flex-col gap-4 overflow-hidden p-4">
 		{@render children()}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
 	import TransactionsScreen from '$lib/screens/TransactionsScreen.svelte';
-	import { State } from '$lib/state.svelte';
-
-	let s = State.shared;
 </script>
 
-<TransactionsScreen bind:state={s} />
+<TransactionsScreen />

--- a/src/routes/accounts/+page.svelte
+++ b/src/routes/accounts/+page.svelte
@@ -1,10 +1,7 @@
 <script>
 	import AccountsScreen from '$lib/screens/AccountsScreen.svelte';
-	import { State } from '$lib/state.svelte';
-
-	let s = State.shared;
 </script>
 
 <title>Accounts – Summer</title>
 
-<AccountsScreen state={s} />
+<AccountsScreen />


### PR DESCRIPTION
Using a static property on the `State` class results in a bunch of Svelte warnings. Doing it this way eliminates the warnings and is much cleaner.