### PR TITLE
fix: make account updates work better

### DIFF
--- a/e2e/accounts.test.ts
+++ b/e2e/accounts.test.ts
@@ -1,0 +1,38 @@
+import { waitFor } from './utils/helpers';
+import { expect, test } from './utils/surrealdb-test';
+
+test('view & update accounts', async ({ page, pageHelpers, createAccount, surreal }) => {
+	await page.goto('/accounts');
+	const newConnectionButton = page.locator('button', { hasText: 'New Connection' });
+	await newConnectionButton.click();
+
+	const account = await createAccount({ name: 'MyBank Checking' });
+
+	// Connect to the database
+	await pageHelpers.connect(page);
+
+	// Check for the account
+	const $accountType = page.getByRole('cell', { name: 'Account Type' }).getByRole('combobox');
+	const $accountName = page.getByRole('cell', { name: 'Account Name' }).getByRole('textbox');
+	const $accountNumber = page.getByRole('cell', { name: 'Account Number' }).getByRole('textbox');
+	const $accountId = page.getByRole('cell', { name: 'Account ID' });
+	await expect(page.getByRole('heading')).toHaveText('Accounts');
+	await expect($accountName).toHaveValue(account.name);
+	await expect($accountType).toHaveValue(account.type);
+	await expect($accountNumber).toHaveValue(account.number!);
+	await expect($accountId).toHaveText(account.id.id.toString());
+
+	// Update the name
+	await $accountName.fill('My New Name');
+	await $accountName.blur();
+	await waitFor(async () => {
+		const updatedAccount = await surreal.select(account.id);
+		console.log(updatedAccount.name);
+		return updatedAccount.name === 'My New Name';
+	});
+
+	await page.getByRole('navigation').click();
+	await page.getByText('Transactions').click();
+	await expect(page.getByRole('heading', { name: 'Transactions' })).toBeVisible();
+	await expect(page.getByText('My New Name')).toBeVisible();
+});

--- a/e2e/utils/helpers.ts
+++ b/e2e/utils/helpers.ts
@@ -9,7 +9,7 @@ export async function waitFor(
 		try {
 			const result = await fn();
 
-			if (result !== true) {
+			if (result === true) {
 				return;
 			}
 		} catch (e) {

--- a/e2e/utils/surrealdb-test.ts
+++ b/e2e/utils/surrealdb-test.ts
@@ -31,6 +31,7 @@ async function waitForPortListening(hostname: string, port: number): Promise<voi
 export interface Account {
 	id: RecordId<'account'>;
 	name: string;
+	number?: string;
 	type: string;
 }
 
@@ -118,6 +119,7 @@ export const test = base.extend<{
 					await surreal.create('account', {
 						id: data.id,
 						name: data.name ?? 'Credit Card',
+						number: data.number ?? '0123456789',
 						type: data.type ?? 'credit'
 					})
 				)[0] as unknown as Account

--- a/src/lib/components/MenuButton.svelte
+++ b/src/lib/components/MenuButton.svelte
@@ -1,8 +1,14 @@
 <script lang="ts">
-	let { isOpen }: { isOpen: boolean } = $props();
+	import type { AriaRole } from 'svelte/elements';
+
+	let { isOpen, role }: { isOpen: boolean; role?: AriaRole } = $props();
 </script>
 
-<div class="flex flex-col items-center justify-center" onfocus={(e) => e.currentTarget.blur()}>
+<div
+	{role}
+	class="flex flex-col items-center justify-center"
+	onfocus={(e) => e.currentTarget.blur()}
+>
 	<span
 		class="block h-0.5 w-6 rounded-sm bg-black transition-all
                     duration-300 ease-out dark:bg-white {isOpen

--- a/src/lib/components/NavigationButton.svelte
+++ b/src/lib/components/NavigationButton.svelte
@@ -11,7 +11,7 @@
 
 <Dropdown content-class="flex items-center">
 	{#snippet trigger(isOpen)}
-		<MenuButton {isOpen} />
+		<MenuButton role="navigation" {isOpen} />
 	{/snippet}
 	{#snippet root(contents)}
 		<div class="relative">

--- a/src/lib/screens/AccountsScreen.svelte
+++ b/src/lib/screens/AccountsScreen.svelte
@@ -1,29 +1,9 @@
 <script lang="ts">
-	import Button from '$lib/components/Button.svelte';
 	import NavigationButton from '$lib/components/NavigationButton.svelte';
-	import type { Account } from '$lib/db';
 	import type { State } from '$lib/state.svelte';
 	import { getContext } from 'svelte';
 
 	const s: State = getContext('state');
-
-	const NEW_ACCOUNT: Partial<Account> = {
-		id: 'new-account',
-		name: 'New Account'
-	};
-
-	let isCreatingAccount = $state(false);
-	let newAccount: Partial<Account> = $state({ ...NEW_ACCOUNT });
-
-	async function onCreateAccount() {
-		const { id, name, number, type } = newAccount;
-		if (!name || !type) {
-			throw new Error('Account fields not set');
-		}
-		await s.createAccount({ id, name, number, type });
-		isCreatingAccount = false;
-		newAccount = { ...NEW_ACCOUNT };
-	}
 </script>
 
 <div class="flex flex-row items-center gap-4">
@@ -43,67 +23,36 @@
 	<tbody>
 		{#each s.filters.accounts as account (account.value.id)}
 			<tr>
-				<td class="p-2">
+				<td role="cell" aria-label="Account Name" class="p-2">
 					<input
 						type="text"
 						value={account.value.name}
-						oninput={(event) => s.updateAccountName(account.value.id, event.currentTarget.value)}
+						onchange={(event) => s.updateAccountName(account.value.id, event.currentTarget.value)}
 						class="p-1 focus:ring-1"
 					/>
 				</td>
-				<td class="p-2">
+				<td role="cell" aria-label="Account Type" class="p-2">
 					<select
-						bind:value={
-							() => account.value.type, (newType) => s.updateAccountType(account.value.id, newType)
-						}
+						value={account.value.type}
+						onchange={(event) => s.updateAccountType(account.value.id, event.currentTarget.value)}
 					>
 						<option value="credit">Credit</option>
 						<option value="checking">Checking</option>
 						<option value="savings">Savings</option>
 					</select>
 				</td>
-				<td class="p-2">
+				<td role="cell" aria-label="Account Number" class="p-2">
 					<input
 						type="text"
 						value={account.value.number}
-						oninput={(event) => s.updateAccountNumber(account.value.id, event.currentTarget.value)}
+						onchange={(event) => s.updateAccountNumber(account.value.id, event.currentTarget.value)}
 						class="p-1 focus:ring-1"
 					/>
 				</td>
-				<td class="p-2" colspan={2}>
+				<td role="cell" aria-label="Account ID" class="p-2">
 					{account.value.id}
 				</td>
 			</tr>
 		{/each}
-
-		{#if isCreatingAccount}
-			<tr class="bg-gray-300 dark:bg-gray-700">
-				<td class="p-2">
-					<input type="text" bind:value={newAccount.name} class="p-1 ring-1" />
-				</td>
-				<td class="p-2">
-					<select bind:value={newAccount.type}>
-						<option value="">Select Type</option>
-						<option value="credit">Credit</option>
-						<option value="checking">Checking</option>
-						<option value="savings">Savings</option>
-					</select>
-				</td>
-				<td class="p-2">
-					<input type="text" bind:value={newAccount.number} class="p-1 ring-1" />
-				</td>
-				<td class="p-2">
-					<input type="text" bind:value={newAccount.id} class="p-1 ring-1" />
-				</td>
-				<td class="p-2">
-					<Button onclick={onCreateAccount} disabled={!newAccount.name || !newAccount.type}>
-						Create
-					</Button>
-					<Button onclick={() => (isCreatingAccount = false)}>Cancel</Button>
-				</td>
-			</tr>
-		{:else}
-			<Button onclick={() => (isCreatingAccount = true)}>New</Button>
-		{/if}
 	</tbody>
 </table>

--- a/src/lib/state.svelte.ts
+++ b/src/lib/state.svelte.ts
@@ -1,4 +1,4 @@
-import { RecordId, Surreal, Table } from 'surrealdb';
+import { RecordId, Surreal } from 'surrealdb';
 import {
 	getFilterOptions,
 	getTransactions,
@@ -242,14 +242,6 @@ export class State {
 		}
 	}
 
-	async createAccount(account: Omit<Account, 'id'> & { id?: string }) {
-		if (!this.#surreal) {
-			throw new Error('Not connected to SurrealDB');
-		}
-		await this.#surreal.create(new Table('account'), account);
-		await this.#updateFilters();
-	}
-
 	async updateAccountName(accountId: string, name: string) {
 		if (!this.#surreal) {
 			throw new Error('Not connected to SurrealDB');
@@ -258,6 +250,7 @@ export class State {
 			id: new RecordId('account', accountId),
 			name
 		});
+		this.#updateFilters();
 	}
 
 	async updateAccountNumber(accountId: string, number?: string) {
@@ -268,6 +261,7 @@ export class State {
 			id: new RecordId('account', accountId),
 			number
 		});
+		this.#updateFilters();
 	}
 
 	async updateAccountType(accountId: string, type: string) {
@@ -278,5 +272,6 @@ export class State {
 			id: new RecordId('account', accountId),
 			type
 		});
+		this.#updateFilters();
 	}
 }


### PR DESCRIPTION
We should stop allowing creating accounts since they should be created by importing statements. Also adds tests for updating account records.