### PR TITLE
fix: ensure `ErrorAlert` components appear above others

### DIFF
--- a/src/lib/components/ErrorAlert.svelte
+++ b/src/lib/components/ErrorAlert.svelte
@@ -6,7 +6,7 @@
 </script>
 
 <div
-	class="absolute top-2 right-2 border-l-4 border-orange-500 bg-orange-100 p-4 text-orange-700"
+	class="absolute top-2 right-2 z-100 border-l-4 border-orange-500 bg-orange-100 p-4 text-orange-700"
 	transition:fly={{ x: '100%', duration: 300, easing: cubicOut }}
 	role="alert"
 >


### PR DESCRIPTION
<img width="505" alt="Screenshot 2025-05-16 at 10 56 19 AM" src="https://github.com/user-attachments/assets/04c1c24f-28b8-431e-8e4b-c24c30d6bf07" />

Previously it would appear behind some elements, such as the filter dropdowns.