### PR TITLE
fix: prevent duplicate statement imports

### DIFF
--- a/static/schema.surql
+++ b/static/schema.surql
@@ -30,6 +30,7 @@ DEFINE TABLE statement SCHEMAFULL;
 DEFINE FIELD account ON TABLE statement TYPE record<account>;
 DEFINE FIELD date ON TABLE statement TYPE datetime;
 DEFINE FIELD file ON TABLE statement TYPE record<file>;
+DEFINE INDEX statementAccountDateIndex ON TABLE statement COLUMNS account, date UNIQUE;
 
 REMOVE TABLE IF EXISTS transaction;
 DEFINE TABLE transaction SCHEMAFULL;


### PR DESCRIPTION
Prevents it both at the DB schema layer and at the application layer in order to provide a better error message.
<img width="505" alt="Screenshot 2025-05-16 at 10 56 19 AM" src="https://github.com/user-attachments/assets/02bb5ac1-67c4-4507-9d9b-0208f63c7685" />
