### PR TITLE
fix: correct selection for "no default category"

### DIFF
--- a/src/lib/screens/CategoriesScreen.svelte
+++ b/src/lib/screens/CategoriesScreen.svelte
@@ -61,7 +61,7 @@
 		{#snippet children(classNames)}
 			<select
 				class={classNames}
-				value={s.defaultCategoryId}
+				value={s.defaultCategoryId ?? ''}
 				onchange={(event) => s.updateDefaultCategoryId(event.currentTarget.value)}
 			>
 				<option value="" disabled>Select Category</option>


### PR DESCRIPTION
When there is no default category, `s.defaultCategoryid` is `undefined`, and this doesn't match the value of the "Select Category" option (which is an empty string). This fixes it by bringing them in line.