### PR TITLE
fix: stop creating `settings:global` in the schema

### DIFF
--- a/static/schema.surql
+++ b/static/schema.surql
@@ -45,4 +45,3 @@ DEFINE FIELD type ON TABLE transaction TYPE string;
 REMOVE TABLE IF EXISTS settings;
 DEFINE TABLE settings SCHEMAFULL;
 DEFINE FIELD defaultCategory ON TABLE settings TYPE option<record<category>>;
-CREATE settings:global;


### PR DESCRIPTION
This was supposed to be part of #44.