### PR TITLE
fix: use {@render} syntax for snippet in BigButton

### DIFF
--- a/src/lib/components/BigButton.svelte
+++ b/src/lib/components/BigButton.svelte
@@ -17,7 +17,7 @@
 
 <Button class="w-60 flex-row items-center px-4 py-2" {onclick}>
 	<span>
-		<Icon />
+		{@render Icon()}
 	</span>
 	<div class="overflow-hidden overflow-ellipsis">
 		<h3 class="flex flex-row items-center gap-2 text-xl whitespace-nowrap">


### PR DESCRIPTION
Fix invalid_snippet_arguments error by using the correct {@render Icon()} syntax instead of calling the snippet like a component with <Icon />.

🤖 Generated with [Claude Code](https://claude.com/claude-code)