### PR TITLE
fix: use statement.date for budget report queries to match transaction screen

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -574,8 +574,8 @@ export async function getBudgetReportData(
 				math::sum((
 					SELECT VALUE amount
 					FROM transaction
-					WHERE date IS NOT NONE
-					AND date.year() == $parent.year
+					WHERE statement.date IS NOT NONE
+					AND statement.date.year() == $parent.year
 					AND category IS NOT NONE
 					AND category.id() IN $parent.categories[*].id.id()
 				)) AS actualAmount
@@ -593,11 +593,11 @@ export async function getBudgetReportData(
 						math::sum(amount) AS monthlyAmount
 					FROM (
 						SELECT
-							date.month() AS month,
+							statement.date.month() AS month,
 							amount
 						FROM transaction
-						WHERE date IS NOT NONE
-						AND date.year() == $parent.year
+						WHERE statement.date IS NOT NONE
+						AND statement.date.year() == $parent.year
 						AND category IS NOT NONE
 						AND category.id() IN $parent.categories[*].id.id()
 					)
@@ -619,11 +619,11 @@ export async function getBudgetReportData(
 						math::sum(amount) AS monthlyAmount
 					FROM (
 						SELECT
-							date.month() AS month,
+							statement.date.month() AS month,
 							amount
 						FROM transaction
-						WHERE date IS NOT NONE
-						AND date.year() == $parent.year - 1
+						WHERE statement.date IS NOT NONE
+						AND statement.date.year() == $parent.year - 1
 						AND category IS NOT NONE
 						AND category.id() IN $parent.categories[*].id.id()
 					)
@@ -752,8 +752,8 @@ export async function getSingleBudgetReportData(
 				math::sum((
 					SELECT VALUE amount
 					FROM transaction
-					WHERE date IS NOT NONE
-					AND date.year() == $parent.year
+					WHERE statement.date IS NOT NONE
+					AND statement.date.year() == $parent.year
 					AND category IS NOT NONE
 					AND category.id() IN $parent.categories[*].id.id()
 				)) AS actualAmount
@@ -771,11 +771,11 @@ export async function getSingleBudgetReportData(
 						math::sum(amount) AS monthlyAmount
 					FROM (
 						SELECT
-							date.month() AS month,
+							statement.date.month() AS month,
 							amount
 						FROM transaction
-						WHERE date IS NOT NONE
-						AND date.year() == $parent.year
+						WHERE statement.date IS NOT NONE
+						AND statement.date.year() == $parent.year
 						AND category IS NOT NONE
 						AND category.id() IN $parent.categories[*].id.id()
 					)
@@ -797,11 +797,11 @@ export async function getSingleBudgetReportData(
 						math::sum(amount) AS monthlyAmount
 					FROM (
 						SELECT
-							date.month() AS month,
+							statement.date.month() AS month,
 							amount
 						FROM transaction
-						WHERE date IS NOT NONE
-						AND date.year() == $parent.year - 1
+						WHERE statement.date IS NOT NONE
+						AND statement.date.year() == $parent.year - 1
 						AND category IS NOT NONE
 						AND category.id() IN $parent.categories[*].id.id()
 					)


### PR DESCRIPTION
Previously, budget report queries used transaction.date while the transaction screen used statement.date, causing discrepancies when these dates differed (e.g., $38.38 difference for Utilities 2025).

Updated all budget report queries (getBudgetReportData and getSingleBudgetReportData) to consistently use statement.date for year and month filtering, ensuring totals match across screens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)