### PR TITLE
fix(reports): cap current-year progress fill at the current month

### DIFF
--- a/e2e/reports.test.ts
+++ b/e2e/reports.test.ts
@@ -116,6 +116,61 @@ test('view budget reports with filtering', async ({ page, createBudget, createCa
 	await expect(page.getByText('Transportation Budget').first()).toBeVisible();
 });
 
+test('current-year progress fill is capped at the current month, ignoring future effective dates', async ({
+	page,
+	createBudget,
+	createCategory,
+	createTransaction,
+	createStatement,
+	surreal
+}) => {
+	const currentYear = new Date().getFullYear();
+	const currentMonth = new Date().getMonth() + 1;
+
+	const category = await createCategory({ name: 'Food', emoji: '🍕' });
+
+	await createBudget({
+		name: 'Food Budget',
+		year: currentYear,
+		amount: -120000, // $1,200 annual budget
+		categories: [category.id]
+	});
+
+	// A normal transaction early in the year.
+	const janStatement = await createStatement({ date: new Date(currentYear, 0, 15) });
+	await createTransaction({
+		statement: janStatement.id,
+		category: category.id,
+		amount: -10000,
+		date: new Date(currentYear, 0, 15),
+		statementDescription: 'Groceries Jan'
+	});
+
+	// A transaction whose *effective date* is in December of the current year — i.e. the
+	// future. This must NOT inflate the year-progress fill beyond where we are in the year.
+	const decStatement = await createStatement({ date: new Date(currentYear, 11, 15) });
+	const futureTx = await createTransaction({
+		statement: decStatement.id,
+		category: category.id,
+		amount: -10000,
+		date: new Date(currentYear, 11, 15),
+		statementDescription: 'Future Groceries'
+	});
+	await surreal.query('UPDATE $id SET effectiveDate = <datetime>$date', {
+		id: futureTx.id,
+		date: `${currentYear}-12-31T00:00:00.000Z`
+	});
+
+	await page.goto('/reports');
+
+	await expect(page.getByText('Loading budget data...')).not.toBeVisible();
+
+	// The fill should reflect progress through the year (current month), not be pushed to
+	// December (12 of 12) by the future-dated transaction.
+	const fill = page.locator('[title$="based on latest transaction"]').first();
+	await expect(fill).toHaveAttribute('title', new RegExp(`^${currentMonth} of 12 months`));
+});
+
 test('reports page with no data', async ({ page }) => {
 	await page.goto('/reports');
 

--- a/src/lib/screens/ReportsScreen.svelte
+++ b/src/lib/screens/ReportsScreen.svelte
@@ -263,8 +263,11 @@
 			}
 		}
 
-		// If no transactions found, fall back to current month
-		return maxMonth > 0 ? maxMonth : new Date().getMonth() + 1;
+		// Cap at the current month: future-dated transactions (e.g. an effective date
+		// later this year) must not fill the progress bar past where we actually are in
+		// the year. Fall back to the current month when there's no spending yet.
+		const currentMonth = new Date().getMonth() + 1;
+		return maxMonth > 0 ? Math.min(maxMonth, currentMonth) : currentMonth;
 	});
 
 	// Stable filtered data that doesn't update while loading


### PR DESCRIPTION
The current-year chart fill derived its height from the latest month with any transaction activity, with no upper bound. A transaction with an effective date later in the year (e.g. December) pushed the fill to 12/12 (100%) even mid-year, instead of reflecting actual progress through the year.

Clamp the computed month to the current month so future-dated transactions no longer inflate the indicator. Adds an e2e regression test.